### PR TITLE
+ Pull request to change SharerWorkflow export file name.

### DIFF
--- a/Controls/ShareWorkflow.ascx.cs
+++ b/Controls/ShareWorkflow.ascx.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -148,7 +148,7 @@ namespace RockWeb.Plugins.com_shepherdchurch.Misc
             Page.EnableViewState = false;
             Page.Response.Clear();
             Page.Response.ContentType = "application/json";
-            Page.Response.AppendHeader( "Content-Disposition", "attachment; filename=export.json" );
+            Page.Response.AppendHeader( "Content-Disposition", string.Format( "attachment; filename={0}_{1}.json" , workflowType.Name.MakeValidFileName(), RockDateTime.Now.ToString( "yyyyMMddHHmm" ) ) );
             Page.Response.Write( Newtonsoft.Json.JsonConvert.SerializeObject( container ) );
             Page.Response.Flush();
             Page.Response.End();


### PR DESCRIPTION
The idea here is to replace "export.json" with a format of "&lt;WF-TYPE-NAME&gt;_&lt;DATE&gt;.json" which is useful when creating multiple workflow exports.  Feel free to close this pull request if you don't care for it.